### PR TITLE
Add basic stat logging setup to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 public/swagger.json
 .vscode/settings.json
 .DS_Store
+log.json


### PR DESCRIPTION
As many of our services expand and use the Faithful API more and more, many endpoints are being accessed thousands of times a day without any optimization or caching. This is obviously undesirable, so Rolf suggested that I log which endpoints are accessed most so we know which endpoints should either be optimized or used by our services less.

This shouldn't reduce the API speed much since I made the entire middleware completely asynchronous and it calls the next() function before making file operations. There may be some concurrency issues but at this scale I'm not too worried by it.